### PR TITLE
Refactor operator to async

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A Kubernetes operator that provides declarative management of Terminal shop reso
 - Automatic dependency resolution between resources
 - Status tracking and error handling
 - Secure credential management
+- Fully asynchronous operator leveraging `AsyncTerminal`
 
 ## Custom Resources
 
@@ -78,6 +79,18 @@ A Kubernetes operator that provides declarative management of Terminal shop reso
    ```
 
 ## Usage Examples
+
+### Creating a Profile
+
+```yaml
+apiVersion: coffee.terminal.sh/v1alpha1
+kind: CoffeeProfile
+metadata:
+  name: my-profile
+spec:
+  email: user@example.com
+  name: Example User
+```
 
 ### Creating a Subscription
 

--- a/charts/terminal-operator/values.yaml
+++ b/charts/terminal-operator/values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: ghcr.io/joshyorko/terminal-operator-k8s
+  repository: ghcr.io/joshyorko/terminal-operator-k8s:feat
   tag: 0.2.0
   pullPolicy: Always
 
@@ -9,7 +9,7 @@ env:
 
 # USE KUBE SECRET FOR TOKEN SECURITY!
 existingSecret: "terminal-api-secret"  # NAME OF SECRET WITH TOKEN
-secretTokenKey: "TERMINAL_BEARER_TOKEN"
+secretTokenKey: "test_e14c18e234e881616aea"
 
 resources: {}
 

--- a/convos/2025-06-24.md
+++ b/convos/2025-06-24.md
@@ -1,0 +1,3 @@
+## Last update was i pushed the docker images,  
+
+## Next step install the current operator onto cluster and test orders

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 kopf
-terminal-shop
+terminal-shop==1.12.0
 python-dotenv
 kubernetes
 click

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,0 +1,36 @@
+import types
+import pytest
+import httpx
+from terminal_operator import main
+
+class DummyResponse:
+    def __init__(self):
+        self.data = {}
+
+@pytest.mark.asyncio
+async def test_handle_profile_success(monkeypatch):
+    async def mock_update(name, email):
+        return DummyResponse()
+    monkeypatch.setattr(main.terminal_client.profile, "update", mock_update)
+    spec = {"name": "User", "email": "user@example.com"}
+    status = {}
+    meta = {"name": "prof", "generation": 1}
+    patch = types.SimpleNamespace(status={})
+    await main.handle_profile(spec, status, meta, patch, logger=main.logger)
+    assert patch.status["phase"] == "Synced"
+    assert "lastSyncTime" in patch.status
+
+@pytest.mark.asyncio
+async def test_handle_profile_api_error(monkeypatch):
+    async def mock_update(name, email):
+        req = httpx.Request("PUT", "https://example.com")
+        resp = httpx.Response(status_code=400, request=req)
+        raise main.APIStatusError("fail", response=resp, body={"code": "bad"})
+    monkeypatch.setattr(main.terminal_client.profile, "update", mock_update)
+    spec = {"name": "User", "email": "user@example.com"}
+    status = {}
+    meta = {"name": "prof", "generation": 1}
+    patch = types.SimpleNamespace(status={})
+    with pytest.raises(main.kopf.PermanentError):
+        await main.handle_profile(spec, status, meta, patch, logger=main.logger)
+


### PR DESCRIPTION
## Summary
- migrate operator handlers to `AsyncTerminal`
- add new `CoffeeProfile` controller with periodic sync
- add async status checks and profile timer
- pin `terminal-shop` dependency
- document async architecture and profile usage
- add tests for profile lifecycle

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a7b90c460832a94733a6bcd8eaa3d